### PR TITLE
[python] Fixed the ApiException handling when it is not HTTP/401

### DIFF
--- a/modules/swagger-codegen/src/main/resources/python/api_client.mustache
+++ b/modules/swagger-codegen/src/main/resources/python/api_client.mustache
@@ -311,7 +311,7 @@ class ApiClient(object):
                     if e.status == 401:
                         self.configuration.refresh_oauth2_token()
                     else:
-                        raise ApiException(e)
+                        raise
             else:
                 raise Exception("Unable to connect server, token is invalid")
         else:


### PR DESCRIPTION
There is no need to wrap ApiException (`e`) inside another ApiException instance.